### PR TITLE
Add Accept header middleware and tests for MCP route

### DIFF
--- a/src/utils/server_config.py
+++ b/src/utils/server_config.py
@@ -1,7 +1,83 @@
 import os
+from typing import Literal
 
 from dotenv import load_dotenv, find_dotenv
 from fastmcp import FastMCP
+from starlette.datastructures import MutableHeaders
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+REQUIRED_MEDIA_TYPES: tuple[str, str] = ("application/json", "text/event-stream")
+
+
+def _normalize_accept_header(raw_value: str | None) -> str:
+    """Ensure the Accept header contains the required media types."""
+
+    values: list[str] = []
+    seen_media_types: set[str] = set()
+
+    if raw_value:
+        for part in raw_value.split(","):
+            normalized = part.strip()
+            if not normalized:
+                continue
+            values.append(normalized)
+            media_type = normalized.split(";", 1)[0].strip().lower()
+            seen_media_types.add(media_type)
+
+    for media_type in REQUIRED_MEDIA_TYPES:
+        if media_type not in seen_media_types:
+            values.append(media_type)
+
+    return ", ".join(values)
+
+
+class MCPAcceptHeaderMiddleware(BaseHTTPMiddleware):
+    """Middleware that ensures MCP requests advertise required media types."""
+
+    def __init__(self, app, *, mcp_path: str) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(app)
+        normalized = mcp_path.rstrip("/") or "/"
+        self._mcp_path = normalized
+
+    def _should_mutate(self, request_path: str) -> bool:
+        if self._mcp_path == "/":
+            return True
+        return request_path == self._mcp_path or request_path.startswith(f"{self._mcp_path}/")
+
+    async def dispatch(self, request, call_next):  # type: ignore[override]
+        if request.scope.get("type") == "http" and self._should_mutate(request.scope.get("path", "")):
+            headers = MutableHeaders(scope=request.scope)
+            headers["accept"] = _normalize_accept_header(headers.get("accept"))
+
+        return await call_next(request)
+
+
+class RecruiteeFastMCP(FastMCP):
+    """FastMCP subclass that injects Accept header middleware for HTTP apps."""
+
+    def http_app(
+        self,
+        path: str | None = None,
+        middleware: list[Middleware] | None = None,
+        json_response: bool | None = None,
+        stateless_http: bool | None = None,
+        transport: Literal["streamable-http", "sse"] = "streamable-http",
+    ):
+        app = super().http_app(
+            path=path,
+            middleware=middleware,
+            json_response=json_response,
+            stateless_http=stateless_http,
+            transport=transport,
+        )
+
+        if transport == "streamable-http":
+            target_path = path or getattr(app.state, "path", "/")
+            app.add_middleware(MCPAcceptHeaderMiddleware, mcp_path=target_path)
+
+        return app
 
 
 
@@ -15,7 +91,7 @@ RECRUITEE_API_TOKEN = os.getenv("RECRUITEE_API_TOKEN")
 BASE_DEPLOY_URL = os.getenv("BASE_DEPLOY_URL")
 
 # Initialize the MCP server
-mcp = FastMCP(
+mcp = RecruiteeFastMCP(
     name="Recruitee Server",
     instructions=_INSTRUCTIONS,
 )

--- a/tests/test_mcp_accept_header.py
+++ b/tests/test_mcp_accept_header.py
@@ -1,0 +1,87 @@
+import unittest
+from typing import Iterable
+
+from fastapi.testclient import TestClient
+from mcp.server.streamable_http import StreamableHTTPServerTransport
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from src.utils.server_config import mcp
+
+
+def _create_app():
+    app = mcp.http_app(path="/mcp")
+
+    async def control_route(request: Request):
+        return JSONResponse({"accept": request.headers.get("accept")})
+
+    app.router.routes.append(Route("/control", control_route, methods=["GET"]))
+    return app
+
+
+class MCPAcceptHeaderTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.captured: list[str | None] = []
+        original = StreamableHTTPServerTransport._check_accept_headers
+
+        def recorder(transport, request):  # type: ignore[no-untyped-def]
+            self.captured.append(request.headers.get("accept"))
+            return original(transport, request)
+
+        StreamableHTTPServerTransport._check_accept_headers = recorder
+        self.addCleanup(
+            lambda: setattr(
+                StreamableHTTPServerTransport,
+                "_check_accept_headers",
+                original,
+            )
+        )
+
+    def _exercise_case(
+        self,
+        accept_header: str | None,
+        expected_control: str,
+        expected_entries: Iterable[str],
+    ) -> None:
+        headers = {}
+        if accept_header is not None:
+            headers["Accept"] = accept_header
+
+        self.captured.clear()
+        with TestClient(_create_app()) as client:
+            client.post(
+                "/mcp",
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            )
+
+            self.assertTrue(self.captured, "Accept header was not inspected by MCP handler")
+            mutated_header = self.captured[-1] or ""
+            mutated_entries = {part.strip() for part in mutated_header.split(",") if part.strip()}
+            for entry in expected_entries:
+                self.assertIn(entry, mutated_entries)
+
+            control_response = client.get("/control", headers=headers)
+            self.assertEqual(control_response.json()["accept"], expected_control)
+
+    def test_accept_header_mutations(self) -> None:
+        scenarios = [
+            (None, "*/*", ("application/json", "text/event-stream")),
+            ("application/json", "application/json", ("application/json", "text/event-stream")),
+            (
+                "application/json;q=0.5",
+                "application/json;q=0.5",
+                ("application/json;q=0.5", "text/event-stream"),
+            ),
+            ("text/event-stream", "text/event-stream", ("application/json", "text/event-stream")),
+        ]
+
+        for accept_header, expected_control, expected_entries in scenarios:
+            with self.subTest(accept_header=accept_header):
+                self._exercise_case(accept_header, expected_control, expected_entries)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add middleware to ensure MCP HTTP apps always advertise both JSON and event-stream media types
- add unit tests covering Accept header normalization across different inputs and confirming non-MCP routes remain unchanged

## Testing
- `.venv/bin/python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_b_68d5af86cdcc832bb934bf6096ac72c9